### PR TITLE
Change type of parameter to information item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,8 @@
               <logResults>true</logResults>
               <excludes>
                 <exclude>org/camunda/bpm/model/dmn/impl/**</exclude>
+                <exclude>org/camunda/bpm/model/dmn/instance/Binding</exclude>
+                <exclude>org/camunda/bpm/model/dmn/instance/ParameterReference</exclude>
               </excludes>
             </configuration>
             <executions>

--- a/src/main/java/org/camunda/bpm/model/dmn/Dmn.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/Dmn.java
@@ -88,7 +88,7 @@ import org.camunda.bpm.model.dmn.impl.instance.OutputEntryImpl;
 import org.camunda.bpm.model.dmn.impl.instance.OutputImpl;
 import org.camunda.bpm.model.dmn.impl.instance.OutputValuesImpl;
 import org.camunda.bpm.model.dmn.impl.instance.OwnerReferenceImpl;
-import org.camunda.bpm.model.dmn.impl.instance.ParameterReferenceImpl;
+import org.camunda.bpm.model.dmn.impl.instance.ParameterImpl;
 import org.camunda.bpm.model.dmn.impl.instance.PerformanceIndicatorImpl;
 import org.camunda.bpm.model.dmn.impl.instance.QuestionImpl;
 import org.camunda.bpm.model.dmn.impl.instance.RelationImpl;
@@ -340,7 +340,7 @@ public class Dmn {
     OutputEntryImpl.registerType(modelBuilder);
     OutputValuesImpl.registerType(modelBuilder);
     OwnerReferenceImpl.registerType(modelBuilder);
-    ParameterReferenceImpl.registerType(modelBuilder);
+    ParameterImpl.registerType(modelBuilder);
     PerformanceIndicatorImpl.registerType(modelBuilder);
     QuestionImpl.registerType(modelBuilder);
     RelationImpl.registerType(modelBuilder);

--- a/src/main/java/org/camunda/bpm/model/dmn/impl/instance/BindingImpl.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/instance/BindingImpl.java
@@ -16,33 +16,29 @@ package org.camunda.bpm.model.dmn.impl.instance;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN11_NS;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_ELEMENT_BINDING;
 
-import org.camunda.bpm.model.dmn.instance.Binding;
-import org.camunda.bpm.model.dmn.instance.Expression;
-import org.camunda.bpm.model.dmn.instance.InformationItem;
-import org.camunda.bpm.model.dmn.instance.ParameterReference;
+import org.camunda.bpm.model.dmn.instance.*;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder.ModelTypeInstanceProvider;
 import org.camunda.bpm.model.xml.type.child.ChildElement;
 import org.camunda.bpm.model.xml.type.child.SequenceBuilder;
-import org.camunda.bpm.model.xml.type.reference.ElementReference;
 
 public class BindingImpl extends DmnModelElementInstanceImpl implements Binding {
 
-  protected static ElementReference<InformationItem, ParameterReference> parameterRef;
+  protected static ChildElement<Parameter> parameterChild;
   protected static ChildElement<Expression> expressionChild;
 
   public BindingImpl(ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
   }
 
-  public InformationItem getParameter() {
-    return parameterRef.getReferenceTargetElement(this);
+  public Parameter getParameter() {
+    return parameterChild.getChild(this);
   }
 
-  public void setParameter(InformationItem parameter) {
-    parameterRef.setReferenceTargetElement(this, parameter);
+  public void setParameter(Parameter parameter) {
+    parameterChild.setChild(this, parameter);
   }
 
   public Expression getExpression() {
@@ -64,9 +60,8 @@ public class BindingImpl extends DmnModelElementInstanceImpl implements Binding 
 
     SequenceBuilder sequenceBuilder = typeBuilder.sequence();
 
-    parameterRef = sequenceBuilder.element(ParameterReference.class)
+    parameterChild = sequenceBuilder.element(Parameter.class)
       .required()
-      .uriElementReference(InformationItem.class)
       .build();
 
     expressionChild = sequenceBuilder.element(Expression.class)

--- a/src/main/java/org/camunda/bpm/model/dmn/impl/instance/ParameterImpl.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/instance/ParameterImpl.java
@@ -16,26 +16,27 @@ package org.camunda.bpm.model.dmn.impl.instance;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN11_NS;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_ELEMENT_PARAMETER;
 
-import org.camunda.bpm.model.dmn.instance.DmnElementReference;
-import org.camunda.bpm.model.dmn.instance.ParameterReference;
+import org.camunda.bpm.model.dmn.instance.InformationItem;
+import org.camunda.bpm.model.dmn.instance.Parameter;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
 import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder.ModelTypeInstanceProvider;
 
-public class ParameterReferenceImpl extends DmnElementReferenceImpl implements ParameterReference {
+public class ParameterImpl extends InformationItemImpl implements Parameter {
 
-  public ParameterReferenceImpl(ModelTypeInstanceContext instanceContext) {
+  public ParameterImpl(ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
   }
 
   public static void registerType(ModelBuilder modelBuilder) {
-    ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(ParameterReference.class, DMN_ELEMENT_PARAMETER)
+    ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(Parameter.class, DMN_ELEMENT_PARAMETER)
       .namespaceUri(DMN11_NS)
-      .extendsType(DmnElementReference.class)
-      .instanceProvider(new ModelTypeInstanceProvider<ParameterReference>() {
-        public ParameterReference newInstance(ModelTypeInstanceContext instanceContext) {
-          return new ParameterReferenceImpl(instanceContext);
+      .extendsType(InformationItem.class)
+      .instanceProvider(new ModelTypeInstanceProvider<Parameter>() {
+        @Override
+        public Parameter newInstance(ModelTypeInstanceContext instanceContext) {
+          return new ParameterImpl(instanceContext);
         }
       });
 

--- a/src/main/java/org/camunda/bpm/model/dmn/instance/Binding.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/instance/Binding.java
@@ -15,9 +15,9 @@ package org.camunda.bpm.model.dmn.instance;
 
 public interface Binding extends DmnModelElementInstance {
 
-  InformationItem getParameter();
+  Parameter getParameter();
 
-  void setParameter(InformationItem parameter);
+  void setParameter(Parameter parameter);
 
   Expression getExpression();
 

--- a/src/main/java/org/camunda/bpm/model/dmn/instance/Parameter.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/instance/Parameter.java
@@ -13,5 +13,5 @@
 
 package org.camunda.bpm.model.dmn.instance;
 
-public interface ParameterReference extends DmnElementReference {
+public interface Parameter extends InformationItem {
 }

--- a/src/test/java/org/camunda/bpm/model/dmn/instance/BindingTest.java
+++ b/src/test/java/org/camunda/bpm/model/dmn/instance/BindingTest.java
@@ -24,7 +24,7 @@ public class BindingTest extends DmnModelElementInstanceTest {
 
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
     return Arrays.asList(
-      new ChildElementAssumption(ParameterReference.class, 1, 1),
+      new ChildElementAssumption(Parameter.class, 1, 1),
       new ChildElementAssumption(Expression.class, 0, 1)
     );
   }

--- a/src/test/java/org/camunda/bpm/model/dmn/instance/ParameterTest.java
+++ b/src/test/java/org/camunda/bpm/model/dmn/instance/ParameterTest.java
@@ -13,6 +13,20 @@
 
 package org.camunda.bpm.model.dmn.instance;
 
-public class ParameterReferenceTest extends AbstractDmnElementReferenceTest {
+import java.util.Collection;
+
+public class ParameterTest extends DmnModelElementInstanceTest {
+
+	public TypeAssumption getTypeAssumption() {
+		return new TypeAssumption(InformationItem.class, false);
+	}
+
+	public Collection<ChildElementAssumption> getChildElementAssumptions() {
+		return null;
+	}
+
+	public Collection<AttributeAssumption> getAttributesAssumptions() {
+		return null;
+	}
 
 }


### PR DESCRIPTION
Currently, `Parameter` is of type `DmnElementReference`. But this is not correct, it should be of type `InformationItem` (see the XSD: https://github.com/camunda/camunda-dmn-model/blob/master/src/main/resources/DMN11.xsd#L223). 

As result, it's not possible to resolve the parameters of an invocation binding.