### PR TITLE
Added schema type information to `InputData.class` and `InputDataReference.class`

### DIFF
--- a/src/main/java/org/camunda/bpm/model/dmn/impl/DmnModelConstants.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/DmnModelConstants.java
@@ -125,6 +125,11 @@ public final class DmnModelConstants {
   public static final String DMN_ELEMENT_USING_TASK = "usingTask";
   public static final String DMN_ELEMENT_VARIABLE = "variable";
 
+  /** DMN schema types */
+
+  public static final String DMN_SCHEMA_TYPE_INPUT_DATA = "tInputData";
+  public static final String DMN_SCHEMA_TYPE_INPUT_DATA_REFERENCE = "tDMNElementReference";
+
   /** DMN attributes */
 
   public static final String DMN_ATTRIBUTE_AGGREGATION = "aggregation";

--- a/src/main/java/org/camunda/bpm/model/dmn/impl/instance/InputDataImpl.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/instance/InputDataImpl.java
@@ -15,6 +15,7 @@ package org.camunda.bpm.model.dmn.impl.instance;
 
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN11_NS;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_ELEMENT_INPUT_DATA;
+import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_SCHEMA_TYPE_INPUT_DATA;
 
 import org.camunda.bpm.model.dmn.instance.DrgElement;
 import org.camunda.bpm.model.dmn.instance.InformationItem;
@@ -45,6 +46,8 @@ public class InputDataImpl extends DrgElementImpl implements InputData {
   public static void registerType(ModelBuilder modelBuilder) {
     ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(InputData.class, DMN_ELEMENT_INPUT_DATA)
       .namespaceUri(DMN11_NS)
+      .schemaTypeName(DMN_SCHEMA_TYPE_INPUT_DATA)
+      .schemaTypeNamespaceUri(DMN11_NS)
       .extendsType(DrgElement.class)
       .instanceProvider(new ModelTypeInstanceProvider<InputData>() {
         public InputData newInstance(ModelTypeInstanceContext instanceContext) {

--- a/src/main/java/org/camunda/bpm/model/dmn/impl/instance/InputDataReferenceImpl.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/instance/InputDataReferenceImpl.java
@@ -15,6 +15,7 @@ package org.camunda.bpm.model.dmn.impl.instance;
 
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN11_NS;
 import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_ELEMENT_INPUT_DATA_REFERENCE;
+import static org.camunda.bpm.model.dmn.impl.DmnModelConstants.DMN_SCHEMA_TYPE_INPUT_DATA_REFERENCE;
 
 import org.camunda.bpm.model.dmn.instance.DmnElementReference;
 import org.camunda.bpm.model.dmn.instance.InputDataReference;
@@ -32,6 +33,8 @@ public class InputDataReferenceImpl extends DmnElementReferenceImpl implements I
   public static void registerType(ModelBuilder modelBuilder) {
     ModelElementTypeBuilder typeBuilder = modelBuilder.defineType(InputDataReference.class, DMN_ELEMENT_INPUT_DATA_REFERENCE)
       .namespaceUri(DMN11_NS)
+      .schemaTypeName(DMN_SCHEMA_TYPE_INPUT_DATA_REFERENCE)
+      .schemaTypeNamespaceUri(DMN11_NS)
       .extendsType(DmnElementReference.class)
       .instanceProvider(new ModelTypeInstanceProvider<InputDataReference>() {
         public InputDataReference newInstance(ModelTypeInstanceContext instanceContext) {

--- a/src/test/java/org/camunda/bpm/model/dmn/ReadWriteTest.java
+++ b/src/test/java/org/camunda/bpm/model/dmn/ReadWriteTest.java
@@ -25,17 +25,18 @@ import static org.camunda.bpm.model.dmn.HitPolicy.PRIORITY;
 import static org.camunda.bpm.model.dmn.HitPolicy.RULE_ORDER;
 import static org.camunda.bpm.model.dmn.HitPolicy.UNIQUE;
 
-import org.camunda.bpm.model.dmn.instance.Decision;
-import org.camunda.bpm.model.dmn.instance.DecisionTable;
-import org.camunda.bpm.model.dmn.instance.Definitions;
-import org.camunda.bpm.model.dmn.instance.Output;
+import org.camunda.bpm.model.dmn.impl.instance.InputDataImpl;
+import org.camunda.bpm.model.dmn.instance.*;
 import org.camunda.bpm.model.dmn.util.DmnModelResource;
 import org.junit.Test;
+
+import java.util.Collection;
 
 public class ReadWriteTest extends DmnModelTest {
 
   public static final String DECISION_TABLE_ORIENTATION_DMN = "org/camunda/bpm/model/dmn/ReadWriteTest.decisionTableOrientation.dmn";
   public static final String HIT_POLICY_DMN = "org/camunda/bpm/model/dmn/ReadWriteTest.hitPolicy.dmn";
+  public static final String INPUT_DATA_DMN = "org/camunda/bpm/model/dmn/ReadWriteTest.inputData.dmn";
 
   @Test
   @DmnModelResource(resource = DECISION_TABLE_ORIENTATION_DMN)
@@ -221,4 +222,18 @@ public class ReadWriteTest extends DmnModelTest {
 
   }
 
+  @Test
+  @DmnModelResource(resource = INPUT_DATA_DMN)
+  public void shouldReadInputData() {
+
+    Collection<InputData> inputDataCollection = modelInstance.getModelElementsByType(InputData.class);
+
+    assertThat(inputDataCollection).hasSize(2);
+    assertThat(inputDataCollection).extracting("class").contains(InputDataImpl.class);
+
+    InputData inputData = modelInstance.getModelElementById("customerStatusIn");
+
+    assertThat(inputData).isNotNull();
+    assertThat(inputData).isInstanceOf(InputData.class);
+  }
 }

--- a/src/test/resources/org/camunda/bpm/model/dmn/ReadWriteTest.inputData.dmn
+++ b/src/test/resources/org/camunda/bpm/model/dmn/ReadWriteTest.inputData.dmn
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Check Order">
+    <extensionElements>
+      <biodi:bounds x="200" y="200" width="180" height="80" />
+    </extensionElements>
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Customer Status">
+        <inputExpression id="inputExpression1" typeRef="string">
+          <text>status</text>
+        </inputExpression>
+        <inputValues id="inputValues">
+          <text><![CDATA["bronze","silver","gold"]]></text>
+        </inputValues>
+      </input>
+      <input id="input2" label="Order Sum">
+        <inputExpression id="inputExpression2" typeRef="double">
+          <text>sum</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="Check Result" name="result" typeRef="string">
+        <outputValues id="outputValues">
+          <text><![CDATA["ok","notok"]]></text>
+        </outputValues>
+      </output>
+      <output id="output2" label="Reason" name="reason" typeRef="string" />
+      <rule id="rule1">
+        <inputEntry id="inputEntry1">
+          <text><![CDATA["bronze"]]></text>
+        </inputEntry>
+        <inputEntry id="inputEntry2">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="outputEntry1">
+          <text><![CDATA["notok"]]></text>
+        </outputEntry>
+        <outputEntry id="outputEntry2">
+          <text><![CDATA["work on your status first, as bronze you're not going to get anything"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="rule2">
+        <inputEntry id="inputEntry3">
+          <text><![CDATA["silver"]]></text>
+        </inputEntry>
+        <inputEntry id="inputEntry4">
+          <text><![CDATA[< 1000]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry3">
+          <text><![CDATA["ok"]]></text>
+        </outputEntry>
+        <outputEntry id="outputEntry4">
+          <text><![CDATA["you little fish will get what you want"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="rule3">
+        <inputEntry id="inputEntry5">
+          <text><![CDATA["silver"]]></text>
+        </inputEntry>
+        <inputEntry id="inputEntry6">
+          <text><![CDATA[>= 1000]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry5">
+          <text><![CDATA["notok"]]></text>
+        </outputEntry>
+        <outputEntry id="outputEntry6">
+          <text><![CDATA["you took too much man, you took too much!"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="rule4">
+        <inputEntry id="inputEntry7">
+          <text><![CDATA["gold"]]></text>
+        </inputEntry>
+        <inputEntry id="inputEntry8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="outputEntry7">
+          <text><![CDATA["ok"]]></text>
+        </outputEntry>
+        <outputEntry id="outputEntry8">
+          <text><![CDATA["you get anything you want"]]></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <inputData id="customerStatusIn" name="Customer Status">
+    <extensionElements>
+      <biodi:bounds x="100" y="320" width="125" height="45" />
+    </extensionElements>
+  </inputData>
+  <inputData id="orderSumIn" name="Order Sum">
+    <extensionElements>
+      <biodi:bounds x="350" y="320" width="125" height="45" />
+    </extensionElements>
+  </inputData>
+</definitions>


### PR DESCRIPTION
Added schema type information to the elements `InputData.class` and `InputDataReference.class` in order to properly differentiate and create them from the model, as they have the same element name. The change uses the changes present in the pull request camunda/camunda-xml-model#7 to add schema type information to the element type instance. 