### PR TITLE
Resolve collision between inputData and inputDataReference

### DIFF
--- a/src/main/java/org/camunda/bpm/model/dmn/impl/DmnModelConstants.java
+++ b/src/main/java/org/camunda/bpm/model/dmn/impl/DmnModelConstants.java
@@ -81,7 +81,7 @@ public final class DmnModelConstants {
   public static final String DMN_ELEMENT_INPUT = "input";
   public static final String DMN_ELEMENT_INPUT_CLAUSE = "inputClause";
   public static final String DMN_ELEMENT_INPUT_DATA = "inputData";
-  public static final String DMN_ELEMENT_INPUT_DATA_REFERENCE = "inputData";
+  public static final String DMN_ELEMENT_INPUT_DATA_REFERENCE = "inputDataReference";
   public static final String DMN_ELEMENT_INPUT_DECISION_REFERENCE = "inputDecision";
   public static final String DMN_ELEMENT_INPUT_ENTRY = "inputEntry";
   public static final String DMN_ELEMENT_INPUT_EXPRESSION = "inputExpression";


### PR DESCRIPTION
I discovered a collision between inputData and inputDataReference while developing a feature for my analysis tool dmn-check. I tried to fetch all inputData objects from a model instance using

```
modelInstance.getModelElementsByType(InputData.class)
```

I got instances of `InputDataReference`. To me it looks like the issue is that there is a collision in `DmnModelConstants`. `DMN_ELEMENT_INPUT_DATA` and `DMN_ELEMENT_INPUT_DATA_REFERENCE` map to `inputData`. I have fixed this and it works for me. However, I am not sure how to write a test case for this change.